### PR TITLE
Return right after showing sub command help

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,6 +122,7 @@ func main() {
 				if len(args) < 2 {
 					logrus.Errorf("You need to pass a key and value to the command. ex: %s %s com.example.apikey EUSJCLLAWE", app.Name, c.Command.Name)
 					cli.ShowSubcommandHelp(c)
+					return
 				}
 
 				// add the key value pair to secrets
@@ -139,6 +140,7 @@ func main() {
 				args := c.Args()
 				if len(args) < 1 {
 					cli.ShowSubcommandHelp(c)
+					return
 				}
 
 				key := args[0]
@@ -167,6 +169,7 @@ func main() {
 				args := c.Args()
 				if len(args) < 1 {
 					cli.ShowSubcommandHelp(c)
+					return
 				}
 
 				// add the key value pair to secrets
@@ -237,6 +240,7 @@ func main() {
 				if len(args) < 2 {
 					logrus.Errorf("You need to pass a key and value to the command. ex: %s %s com.example.apikey EUSJCLLAWE", app.Name, c.Command.Name)
 					cli.ShowSubcommandHelp(c)
+					return
 				}
 
 				// add the key value pair to secrets


### PR DESCRIPTION
Hi @jfrazelle

I noticed that when running the following sub commands (add, update, delete, get), if the arguments check fails, it continues the action, which in most cases will result in a panic / index out of range and stack trace:

```
mark at evilcorp ~/workspace/go/src/github.com/markstgodard/pony(master ✓) $ pony add
GPG Passphrase for key Mark St.Godard <markstgodard@gmail.com>:

ERRO[0002] You need to pass a key and value to the command. ex: pony add com.example.apikey EUSJCLLAWE
NAME:
   pony add - Add a new secret

USAGE:
   pony add [arguments...]
panic: runtime error: index out of range

goroutine 1 [running]:
main.func·001(0xc208092b40)
    /Users/mark/workspace/go/src/github.com/markstgodard/pony/main.go:128 +0x3bf
github.com/codegangsta/cli.Command.Run(0x2b27d0, 0x3, 0x0, 0x0, 0xc208032550, 0x1, 0x1, 0x2d1750, 0x10, 0x0, ...)
    /Users/mark/workspace/go/src/github.com/codegangsta/cli/command.go:131 +0x1001
github.com/codegangsta/cli.(*App).Run(0xc208000fc0, 0xc20800a000, 0x2, 0x2, 0x0, 0x0)
    /Users/mark/workspace/go/src/github.com/codegangsta/cli/app.go:175 +0x1184
main.main()
    /Users/mark/workspace/go/src/github.com/markstgodard/pony/main.go:250 +0xf0e

goroutine 5 [syscall]:
os/signal.loop()
    /usr/local/go/src/os/signal/signal_unix.go:21 +0x1f
created by os/signal.init·1
    /usr/local/go/src/os/signal/signal_unix.go:27 +0x35

goroutine 6 [chan receive]:
github.com/docker/docker/pkg/term.func·001()
    /Users/mark/workspace/go/src/github.com/docker/docker/pkg/term/term.go:128 +0x64
created by github.com/docker/docker/pkg/term.handleInterrupt
    /Users/mark/workspace/go/src/github.com/docker/docker/pkg/term/term.go:131 +0x1d5

goroutine 7 [runnable]:
text/template/parse.lexText(0xc20807c080, 0x32d268)
    /usr/local/go/src/text/template/parse/lex.go:228 +0x37b
text/template/parse.(*lexer).run(0xc20807c080)
    /usr/local/go/src/text/template/parse/lex.go:198 +0x5d
created by text/template/parse.lex
    /usr/local/go/src/text/template/parse/lex.go:191 +0x1ac
mark at evilcorp ~/workspace/go/src/github.com/markstgodard/pony(master ✓) $
```

I just changed to return from the sub command function, if the required args check fails vs continuing.

```
mark at evilcorp ~/workspace/go/src/github.com/markstgodard/pony(master ✓) $ ./pony add
GPG Passphrase for key Mark St.Godard <markstgodard@gmail.com>:

ERRO[0002] You need to pass a key and value to the command. ex: pony add com.example.apikey EUSJCLLAWE
NAME:
   add - Add a new secret

USAGE:
   command add [arguments...]
mark at evilcorp ~/workspace/go/src/github.com/markstgodard/pony(master ✓) $
```

Its not a major issue, just something I noticed and thought I could fix.

Oh and thanks!  I use your tool all the time

Cheers
@markstgodard
