### PR TITLE
Create/wipe db after gpg encrypt has completed successfully

### DIFF
--- a/store.go
+++ b/store.go
@@ -39,12 +39,6 @@ func readSecretsFile(filename string) (s secretFile, err error) {
 // writeSecretsFile takes a SecretsFile struct and marshals, encrypts, and
 // writes it to the secrets filestore.
 func writeSecretsFile(filename string, s secretFile) error {
-	f, err := os.Create(file)
-	if err != nil {
-		return fmt.Errorf("could not create filestore for secrets at %s: %v", file, err)
-	}
-	defer f.Close()
-
 	b, err := json.Marshal(s)
 	if err != nil {
 		return fmt.Errorf("marshaling secret file to json failed: %v", s)
@@ -55,6 +49,12 @@ func writeSecretsFile(filename string, s secretFile) error {
 	if err != nil {
 		return fmt.Errorf("gpg encrypt on file create failed: %v", err)
 	}
+
+	f, err := os.Create(file)
+	if err != nil {
+		return fmt.Errorf("could not create filestore for secrets at %s: %v", file, err)
+	}
+	defer f.Close()
 
 	if _, err := f.Write(eb); err != nil {
 		return fmt.Errorf("writing to file failed: %v", err)


### PR DESCRIPTION
Hey,

`pony` didn't take kindly to me interrupting `pony create` 😄.

```console
$ pony create foo bar
You did not specify a user ID. (you may use "-r")

Current recipients:

Enter the user ID.  End with an empty line: ^C

$ pony ls
FATA[0000] gpg decrypt file failed: gpg [gpg --decrypt] failed with stdout "", error: exit status 2
```

Here's a quick fix that just delays `os.Create` until gpg encrypt succeeded.